### PR TITLE
Allow restricting the base path when adding from the library

### DIFF
--- a/lib/mpdrandom.py
+++ b/lib/mpdrandom.py
@@ -92,7 +92,7 @@ class Client(MPDClient):
             albums = await self.getalbums()
             toplay = await self.random_album(albums)
             if toplay:  # Make sure we found a random album
-                self.play_album(albums[toplay])
+                await self.play_album(albums[toplay])
             else:
                 print("Nothing to play.")
         else:  # Play from the library

--- a/lib/mpdrandom.py
+++ b/lib/mpdrandom.py
@@ -18,7 +18,7 @@
 
 from argparse import ArgumentParser
 from mpd.asyncio import MPDClient
-from mpd.base import VERSION
+from mpd.base import VERSION, CommandError
 from threading import Thread
 import asyncio
 import random
@@ -100,7 +100,11 @@ class Client(MPDClient):
                 self.clear()
             album_name = None
             if base:
-                album_name = random.choice(await self.list('album', 'base', base))
+                try:
+                    album_name = random.choice(await self.list('album', 'base', base))
+                except CommandError as e:
+                    print("Base directory '{}' invalid: {}".format(base, e))
+                    raise SystemExit
             else:
                 album_name = random.choice(await self.list('album'))
 


### PR DESCRIPTION
Basically what the title says, it allows restricting the directory from which to add albums in library mode. The directory is relative to the music library in mpd.

Minor caveat: In daemon mode, it will take up to the first album adding for the program to crash if the path doesn't exist.